### PR TITLE
Add page templates, blog post template, and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,32 @@ npm run preview  # preview the built site locally
 
 ```
 src/
-  pages/             # Astro pages (.astro files)
+  pages/
+    index.astro        # Homepage: hero, mission, programs, latest news, CTA
+    [slug].astro       # Dynamic route for content/pages collection
+    blog/
+      [slug].astro     # Dynamic route for content/blog collection
   layouts/
-    Base.astro       # Main layout: header, nav, footer, SEO metadata
-    BlogPost.astro   # Blog post layout: date, author, body
+    Base.astro         # Main layout: header, nav, footer, SEO metadata
+    BlogPost.astro     # Blog post layout: date, author, body
   content/
-    pages/           # Static content pages (.md)
-    blog/            # Blog posts (.md)
-  data/              # Structured data files (.yaml)
-  components/        # Reusable Astro components
+    config.ts          # Content collection schemas (pages + blog)
+    pages/             # Static content pages (.md) — rendered via [slug].astro
+    blog/              # Blog posts (.md) — rendered via blog/[slug].astro
+  data/                # Structured data files (.yaml)
+  components/          # Reusable Astro components
     HeroSection.astro  # Large banner with title and subtitle
     PersonCard.astro   # Person display: name, role, bio, image, website
     EventCard.astro    # Event display: date, location, description, link
   assets/
-    images/          # Site images
+    images/            # Site images
 public/
-  styles.css         # Global CSS
-docs/                # Project documentation and design specs
+  styles.css           # Global CSS
+docs/                  # Project documentation and design specs
 ```
+
+## Adding content
+
+**New page:** create `src/content/pages/<slug>.md` with `title` (and optionally `description`) in frontmatter. It will be served at `/<slug>/`.
+
+**New blog post:** create `src/content/blog/<slug>.md` with `title`, `date`, and optionally `author` and `description` in frontmatter. It will be served at `/blog/<slug>/`. The homepage automatically shows the three most recent posts.

--- a/docs/superpowers/plans/2026-05-01-wordpress-migration.md
+++ b/docs/superpowers/plans/2026-05-01-wordpress-migration.md
@@ -804,42 +804,13 @@ git commit -m "Create EventCard component for displaying events/programs"
 **Files:**
 - Create: `src/pages/[slug].astro`
 
-- [ ] **Step 1: Write [slug].astro**
+> **Implemented in PR #N (issue #4).** Uses `getCollection('pages')` for static path generation. Renders page title as an `<h1>` outside the `<Content />` component, wrapped in `content-page` / `prose` CSS classes consistent with the global stylesheet.
 
-```astro
----
-import { getCollection } from 'astro:content';
-import Base from '../layouts/Base.astro';
+- [x] **Step 1: Write [slug].astro**
 
-export async function getStaticPaths() {
-  const pages = await getCollection('pages');
-  return pages.map(page => ({
-    params: { slug: page.slug },
-    props: { page }
-  }));
-}
+- [x] **Step 2: Verify file created**
 
-const { page } = Astro.props;
-const { Content } = await page.render();
----
-
-<Base title={page.data.title} description={page.data.description}>
-  <Content />
-</Base>
-```
-
-- [ ] **Step 2: Verify file created**
-
-```bash
-cat src/pages/\[slug\].astro
-```
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/pages/\[slug\].astro
-git commit -m "Create dynamic page template for content collection pages"
-```
+- [x] **Step 3: Commit**
 
 ---
 
@@ -848,53 +819,15 @@ git commit -m "Create dynamic page template for content collection pages"
 **Files:**
 - Create: `src/pages/blog/[slug].astro`
 
-- [ ] **Step 1: Create blog directory**
+> **Implemented in PR #N (issue #4).** Uses `getCollection('blog')` for static path generation. Passes `title`, `date`, `author`, and `description` from frontmatter to the `BlogPost` layout, then renders `<Content />` inside it.
 
-```bash
-mkdir -p src/pages/blog
-```
+- [x] **Step 1: Create blog directory**
 
-- [ ] **Step 2: Write blog/[slug].astro**
+- [x] **Step 2: Write blog/[slug].astro**
 
-```astro
----
-import { getCollection } from 'astro:content';
-import BlogPost from '../../layouts/BlogPost.astro';
+- [x] **Step 3: Verify file created**
 
-export async function getStaticPaths() {
-  const blogPosts = await getCollection('blog');
-  return blogPosts.map(post => ({
-    params: { slug: post.slug },
-    props: { post }
-  }));
-}
-
-const { post } = Astro.props;
-const { Content } = await post.render();
----
-
-<BlogPost 
-  title={post.data.title}
-  date={post.data.date}
-  author={post.data.author}
-  description={post.data.description}
->
-  <Content />
-</BlogPost>
-```
-
-- [ ] **Step 3: Verify file created**
-
-```bash
-cat src/pages/blog/\[slug\].astro
-```
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add src/pages/blog/
-git commit -m "Create blog post template for blog collection"
-```
+- [x] **Step 4: Commit**
 
 ---
 
@@ -903,7 +836,9 @@ git commit -m "Create blog post template for blog collection"
 **Files:**
 - Create: `src/pages/index.astro`
 
-- [ ] **Step 1: Write index.astro**
+> **Implemented in PR #N (issue #4).** Homepage includes: `HeroSection` with tagline, mission section, programs grid (Conference, Fellowship, Progress in Medicine), dynamic latest-news section driven by the blog collection (sorted by date, up to 3 posts, shown via `EventCard`), and a support CTA section. The news section is conditionally rendered and will populate automatically as blog posts are added.
+
+- [x] **Step 1: Write index.astro**
 
 ```astro
 ---
@@ -977,18 +912,9 @@ const recentNews = [];
 </style>
 ```
 
-- [ ] **Step 2: Verify file created**
+- [x] **Step 2: Verify file created**
 
-```bash
-head -40 src/pages/index.astro
-```
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/pages/index.astro
-git commit -m "Create homepage with hero section and event previews"
-```
+- [x] **Step 3: Commit**
 
 ---
 
@@ -999,7 +925,9 @@ git commit -m "Create homepage with hero section and event previews"
 **Files:**
 - Create: `src/content/config.ts`
 
-- [ ] **Step 1: Write config.ts**
+> **Implemented in PR #N (issue #4).** Required by the page templates; implemented early. Schema uses `z.coerce.date()` (not `z.date()`) to handle ISO date strings from markdown frontmatter. Blog schema: `title` (required), `date` (required, coerced), `author` and `description` (optional). Pages schema: `title` (required), `description` and `order` (optional).
+
+- [x] **Step 1: Write config.ts**
 
 ```typescript
 import { defineCollection, z } from 'astro:content';
@@ -1027,18 +955,9 @@ const blog = defineCollection({
 export const collections = { pages, blog };
 ```
 
-- [ ] **Step 2: Verify file created**
+- [x] **Step 2: Verify file created**
 
-```bash
-cat src/content/config.ts
-```
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add src/content/config.ts
-git commit -m "Add Astro content collection schema configuration"
-```
+- [x] **Step 3: Commit**
 
 ---
 

--- a/src/content/blog/welcome.md
+++ b/src/content/blog/welcome.md
@@ -1,0 +1,21 @@
+---
+title: Welcome to the New Roots of Progress Website
+date: 2026-05-01
+author: Jason Crawford
+description: We've launched our new website built on Astro, making it faster and easier to maintain.
+---
+
+We're excited to announce the launch of our new website, built on [Astro](https://astro.build)—a modern static site generator that makes our site faster, more secure, and easier for the whole team to maintain.
+
+## What's New
+
+Our new site is built with:
+- **Astro** for fast, static HTML pages
+- **Markdown** for content that the whole team can edit
+- **Git** as our source of truth, with automatic deployments
+
+## What This Means for You
+
+The site is faster and more secure than our previous WordPress installation. Content updates are handled through git, making it easy to version-control all changes and collaborate as a team.
+
+Stay tuned for more updates as we continue to improve the site and migrate all of our content.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,22 @@
+import { defineCollection, z } from 'astro:content';
+
+const pages = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    order: z.number().optional(),
+  }),
+});
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    author: z.string().optional(),
+    description: z.string().optional(),
+  }),
+});
+
+export const collections = { pages, blog };

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -1,0 +1,19 @@
+---
+title: About
+description: Learn about Roots of Progress and our mission to build a culture of progress.
+order: 1
+---
+
+Roots of Progress is a nonprofit dedicated to establishing a new philosophy of progress for the 21st century.
+
+## Our Story
+
+Roots of Progress was founded on the belief that human progress—economic, scientific, and technological—is one of the most important forces for good in the world, and that we need to understand its causes and work to accelerate it.
+
+## Our Team
+
+We are a small, passionate team of researchers, writers, and program builders committed to the mission of progress.
+
+## Get Involved
+
+Interested in supporting our work? Visit our [support page](/support/) to learn how you can help.

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../layouts/Base.astro';
+
+export async function getStaticPaths() {
+  const pages = await getCollection('pages');
+  return pages.map((page) => ({
+    params: { slug: page.slug },
+    props: { page },
+  }));
+}
+
+const { page } = Astro.props;
+const { Content } = await page.render();
+---
+
+<Base title={page.data.title} description={page.data.description}>
+  <article class="content-page">
+    <div class="content-page-inner">
+      <h1>{page.data.title}</h1>
+      <div class="prose">
+        <Content />
+      </div>
+    </div>
+  </article>
+</Base>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,24 @@
+---
+import { getCollection } from 'astro:content';
+import BlogPost from '../../layouts/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+
+<BlogPost
+  title={post.data.title}
+  date={post.data.date}
+  author={post.data.author}
+  description={post.data.description}
+>
+  <Content />
+</BlogPost>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,86 @@
 ---
+import { getCollection } from 'astro:content';
 import Base from '../layouts/Base.astro';
+import HeroSection from '../components/HeroSection.astro';
+import EventCard from '../components/EventCard.astro';
+
+const recentPosts = (await getCollection('blog'))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 3);
 ---
 
-<Base title="Roots of Progress">
-  <h1>Roots of Progress</h1>
-  <p>A culture of progress for the 21st century.</p>
+<Base
+  title="Roots of Progress"
+  description="A culture of progress for the 21st century. Roots of Progress is a nonprofit dedicated to understanding and accelerating human progress."
+>
+  <HeroSection
+    title="A culture of progress for the 21st century"
+    subtitle="While humanity has achieved remarkable progress over the past few centuries, we can and should accelerate it further."
+  />
+
+  <section class="mission-section">
+    <div class="section-inner">
+      <h2>Our Mission</h2>
+      <p>
+        Roots of Progress is a nonprofit dedicated to establishing a new philosophy of progress
+        — one that supports innovation, science, and technology as forces for human flourishing.
+        We run programs in research, education, and community-building to help make progress
+        both faster and more broadly beneficial.
+      </p>
+      <a href="/about/" class="btn">Learn more about us</a>
+    </div>
+  </section>
+
+  <section class="programs-section">
+    <div class="section-inner">
+      <h2>Our Programs</h2>
+      <div class="programs-grid">
+        <div class="program-card">
+          <h3>Fellowship</h3>
+          <p>Support for researchers and writers working on progress-relevant topics.</p>
+          <a href="/programs/">Learn more →</a>
+        </div>
+        <div class="program-card">
+          <h3>Conference</h3>
+          <p>Annual gathering of researchers, entrepreneurs, and philanthropists.</p>
+          <a href="/programs/">Learn more →</a>
+        </div>
+        <div class="program-card">
+          <h3>Progress in Medicine</h3>
+          <p>Exploring the history and future of medical innovation.</p>
+          <a href="/programs/">Learn more →</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {recentPosts.length > 0 && (
+    <section class="news-section">
+      <div class="section-inner">
+        <h2>Latest News</h2>
+        <div class="card-grid">
+          {recentPosts.map((post) => (
+            <EventCard
+              title={post.data.title}
+              date={post.data.date.toISOString().split('T')[0]}
+              description={post.data.description}
+              link={`/blog/${post.slug}/`}
+            />
+          ))}
+        </div>
+        <a href="/blog/" class="btn btn-secondary">View all posts</a>
+      </div>
+    </section>
+  )}
+
+  <section class="cta-section">
+    <div class="section-inner">
+      <h2>Support Our Work</h2>
+      <p>
+        Help us build a culture that values and accelerates human progress.
+        Your support funds fellowships, conferences, and research.
+      </p>
+      <a href="/support/" class="btn">Support Roots of Progress</a>
+    </div>
+  </section>
 </Base>


### PR DESCRIPTION
## Summary

- `src/content/config.ts`: defines `pages` and `blog` content collections with Zod schemas (needed by the dynamic routes)
- `src/pages/[slug].astro`: dynamic route for `content/pages` collection — renders title + markdown body via `Base` layout
- `src/pages/blog/[slug].astro`: dynamic route for `content/blog` collection — renders title, date, author, and body via `BlogPost` layout
- `src/pages/index.astro`: homepage rebuilt with `HeroSection`, mission section, programs grid, dynamic latest-news section (pulls up to 3 recent blog posts via `EventCard`), and support CTA
- `src/content/pages/about.md` + `src/content/blog/welcome.md`: sample content to exercise the dynamic routes and verify the build

Plan doc updated to mark Tasks 13–16 complete.

## Test plan

- [x] `npm run build` succeeds with zero errors
- [x] `/about/index.html` generated with correct title, description OG tag, and prose content
- [x] `/blog/welcome/index.html` generated with title, formatted date, author byline, and body
- [x] `/index.html` includes all five sections: `hero-section`, `mission-section`, `programs-section`, `news-section`, `cta-section`
- [x] Latest blog post title appears in homepage news section

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)