### PR TITLE
Add sample content pages and blog posts

### DIFF
--- a/docs/superpowers/plans/2026-05-01-wordpress-migration.md
+++ b/docs/superpowers/plans/2026-05-01-wordpress-migration.md
@@ -966,7 +966,9 @@ export const collections = { pages, blog };
 **Files:**
 - Create: `src/content/pages/about.md`, `src/content/pages/support.md`
 
-- [ ] **Step 1: Write about.md**
+> **Implemented across PR #18 (issue #4) and PR #19 (issue #5).** `about.md` was created in issue #4 alongside the content collection config. `support.md` was added in issue #5 with `title`, `description`, and `order` frontmatter. Both render via `[slug].astro`.
+
+- [x] **Step 1: Write about.md**
 
 ```markdown
 ---
@@ -997,7 +999,7 @@ We offer several programs focused on advancing progress studies as a discipline 
 Have questions? [Contact us](mailto:contact@rootsofprogress.org)
 ```
 
-- [ ] **Step 2: Write support.md**
+- [x] **Step 2: Write support.md**
 
 ```markdown
 ---
@@ -1030,13 +1032,13 @@ Interested in volunteering? [Get in touch](mailto:contact@rootsofprogress.org)
 Roots of Progress is a 501(c)(3) nonprofit organization.
 ```
 
-- [ ] **Step 3: Verify files created**
+- [x] **Step 3: Verify files created**
 
 ```bash
 wc -l src/content/pages/*.md
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/content/pages/about.md src/content/pages/support.md
@@ -1050,7 +1052,9 @@ git commit -m "Add sample pages (About, Support) for testing"
 **Files:**
 - Create: `src/content/blog/first-post.md`, `src/content/blog/second-post.md`
 
-- [ ] **Step 1: Write first-post.md**
+> **Implemented across PR #18 (issue #4) and PR #19 (issue #5).** `welcome.md` (serving as the first post) was created in issue #4. `progress-conference-2026.md` (serving as the second post) was added in issue #5. Filenames differ from the plan but the frontmatter schema and rendered routes are equivalent.
+
+- [x] **Step 1: Write first-post.md**
 
 ```markdown
 ---
@@ -1081,7 +1085,7 @@ Our new static site approach provides:
 We'll be continuously improving this site. Stay tuned for updates on our programs and initiatives.
 ```
 
-- [ ] **Step 2: Write second-post.md**
+- [x] **Step 2: Write second-post.md**
 
 ```markdown
 ---
@@ -1108,13 +1112,13 @@ We're assembling an impressive lineup of thinkers, scientists, and entrepreneurs
 [Learn more and apply →](/programs/)
 ```
 
-- [ ] **Step 3: Verify files created**
+- [x] **Step 3: Verify files created**
 
 ```bash
 ls -la src/content/blog/
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/content/blog/

--- a/src/content/blog/progress-conference-2026.md
+++ b/src/content/blog/progress-conference-2026.md
@@ -1,0 +1,31 @@
+---
+title: Announcing the Progress Conference 2026
+date: 2026-05-15
+author: Jason Crawford
+description: Join us in Berkeley this October for our annual gathering of progress thinkers, scientists, and entrepreneurs.
+---
+
+We're thrilled to announce the **Progress Conference 2026**, happening October 8–11 in Berkeley, California.
+
+## What to Expect
+
+The Progress Conference brings together leading thinkers, scientists, historians, and entrepreneurs who are advancing human progress. Over four days, you'll hear talks, join workshops, and connect with a community that shares a deep commitment to understanding and accelerating progress.
+
+## Conference Tracks
+
+This year's program will explore progress across multiple dimensions:
+
+- **Technology & Innovation** — How new tools and platforms are reshaping what's possible
+- **Science & Medicine** — Breakthroughs in longevity, biotechnology, and the future of health
+- **History & Philosophy** — What we can learn from the great eras of progress in the past
+- **Society & Culture** — How our beliefs and institutions shape our relationship with progress
+
+## Who Should Attend
+
+The Progress Conference is designed for researchers, writers, founders, students, and anyone who cares deeply about the future of human flourishing. Whether you're new to progress studies or a longtime reader, you'll find conversations worth having and connections worth making.
+
+## How to Apply
+
+Space is limited. Applications will open in late June. [Subscribe to our newsletter](https://rootsofprogress.substack.com/) to be notified when applications open.
+
+We look forward to seeing you in Berkeley.

--- a/src/content/pages/support.md
+++ b/src/content/pages/support.md
@@ -1,0 +1,29 @@
+---
+title: Support Our Work
+description: Help us advance progress studies and build a culture of progress for the 21st century.
+order: 4
+---
+
+Roots of Progress is a nonprofit dedicated to understanding and advocating for human progress. Your support makes our work possible.
+
+## Ways to Give
+
+### Monthly Support
+
+Join our community of supporters on [Patreon](https://www.patreon.com/rootsofprogress) and get access to exclusive updates, early drafts, and behind-the-scenes content.
+
+### One-Time Gift
+
+Make a one-time donation via [PayPal](https://www.paypal.com/donate/?hosted_button_id=ROOTSOFPROGRESS) to support our mission.
+
+### Other Ways to Help
+
+- **Subscribe** to our newsletter on [Substack](https://rootsofprogress.substack.com/) to stay informed and help spread the word.
+- **Share** our work with friends, colleagues, and communities who care about human progress.
+- **Volunteer** your expertise—[reach out](mailto:contact@rootsofprogress.org) if you'd like to get involved.
+
+## Why Support Us?
+
+Roots of Progress is building the intellectual foundations for a new philosophy of progress. We study the history and drivers of human advancement, run programs that develop the next generation of progress thinkers, and work to rebuild a cultural appreciation for progress in modern society.
+
+Roots of Progress is a 501(c)(3) nonprofit organization. Donations are tax-deductible to the extent permitted by law.


### PR DESCRIPTION
## Summary

- Adds `src/content/pages/support.md` — the Support page referenced in site navigation (previously missing)
- Adds `src/content/blog/progress-conference-2026.md` — a second sample blog post to exercise the blog collection

Both files use frontmatter matching the Zod schemas already defined in `src/content/config.ts`. The build now generates 6 static pages (up from 4), including `/support/` and `/blog/progress-conference-2026/`.

The `src/content/config.ts` schema and `src/content/pages/about.md` / `src/content/blog/welcome.md` were already in place from issue #4.

## Test plan

- [x] `npm run build` completes without errors, generating all 6 expected pages
- [x] `npx tsc --noEmit` passes with no type errors
- [ ] CI passes on this PR

Closes #5