### PR TITLE
Allow rootsofprogress.org in devcontainer firewall

### DIFF
--- a/.devcontainer/firewall-extras.txt
+++ b/.devcontainer/firewall-extras.txt
@@ -1,0 +1,3 @@
+# Roots of Progress domain for content scraping
+rootsofprogress.org
+www.rootsofprogress.org


### PR DESCRIPTION
Enable outbound HTTPS access to rootsofprogress.org from devcontainer so web scraping agent can extract content in Issue #7.

## Changes
- Add .devcontainer/firewall-extras.txt with rootsofprogress.org domain allowlist

## Setup
After merging, restart devcontainer:
```bash
devcontainer down --workspace-folder .
devcontainer up --workspace-folder .
```

Issue #7 agent will then be able to scrape the live site.