### PR TITLE
Update migration plan with correct content extraction approach

### DIFF
--- a/docs/superpowers/plans/2026-05-01-wordpress-migration.md
+++ b/docs/superpowers/plans/2026-05-01-wordpress-migration.md
@@ -1291,40 +1291,52 @@ Expected: HTML files for all pages in dist/.
 
 ## Phase 1h: WordPress Content Extraction
 
-### Task 23: Prepare WordPress content export
+### Task 23: Extract WordPress content via direct HTTP scraping
 
 **Files:**
-- Create: scripts directory, export lists
+- Create: `scripts/extract-content.mjs`
 
-This task is a guide for exporting WordPress content. You'll need to:
+> **⚠️ CRITICAL: Do NOT use WebFetch (or any LLM-mediated tool) to extract content.** WebFetch returns an LLM-summarized interpretation of the page, not the raw text — this silently paraphrases every piece of content and makes the migration useless. The LLM writes the script; the script runs without the LLM. See the `verbatim-content-extraction` skill.
 
-- [ ] **Step 1: Export WordPress posts via XML**
+> **Note on XML export:** WordPress page builders (like the one used on rootsofprogress.org) store body content in a custom serialized format in the database. The XML export body fields are not reliable for migration. **Always scrape rendered HTML from the live site.**
 
-From WordPress admin panel:
-1. Go to **Tools > Export**
-2. Select **All content**
-3. Download the XML file as `wp-export.xml`
-4. Save to root of project: `/Users/jason/projects/rpi-homepage/wp-export.xml`
+The correct pipeline is: `fetch() → raw HTML → cheerio/node-html-parser → turndown → verbatim markdown`
 
-Expected: XML file with all posts, pages, metadata
+- [ ] **Step 1: Discover all URLs via sitemap**
 
-- [ ] **Step 2: Create extraction script plan**
+```bash
+curl https://rootsofprogress.org/sitemap_index.xml
+```
 
-We'll use Claude Code to help convert the WordPress XML to markdown files. The process:
-1. Parse XML file
-2. For each post/page:
-   - Extract title, content, date, author, featured image
-   - Convert HTML content to markdown
-   - Create frontmatter with metadata
-   - Save as `src/content/blog/[slug].md` or `src/content/pages/[slug].md`
+This returns a sitemap index. Each subsidiary sitemap (e.g. `post-sitemap.xml`, `page-sitemap.xml`, `fellow-sitemap.xml`, `advisory-sitemap.xml`) lists the URLs to scrape.
 
-- [ ] **Step 3: Download WordPress images**
+- [ ] **Step 2: Write extraction script**
 
-1. Use WordPress admin or FTP to access `/wp-content/uploads/`
-2. Download all images
-3. Organize into `src/assets/images/` with structure like: `src/assets/images/2024/post-slug/image.jpg`
+Install dependencies:
+```bash
+npm install turndown node-html-parser
+```
 
-**Note:** This will be handled with Claude Code assistance.
+Write `scripts/extract-content.mjs` using Node.js `fetch()` to download each URL, `node-html-parser` to parse HTML and extract the content container, and `turndown` to convert HTML to markdown. Extract frontmatter fields (title, date, author, description) from page metadata.
+
+- [ ] **Step 3: Run and spot-check**
+
+```bash
+node scripts/extract-content.mjs
+```
+
+Spot-check at least 5 extracted files by comparing title, first paragraph, and last paragraph against the live site. Any mismatch means the content selector is wrong — fix the script, not the markdown files.
+
+- [ ] **Step 4: Download images**
+
+Profile images are at non-predictable CDN paths. Scrape each profile page, extract the `wp-content/uploads` image URL from the `<img>` tag, then download. See the existing `scripts/download-images.mjs` for this pattern.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ src/content/ src/data/ src/assets/images/
+git commit -m "Migrate WordPress content via direct HTML scraping (issue #24)"
+```
 
 ---
 

--- a/docs/superpowers/specs/2026-05-01-wordpress-migration-design.md
+++ b/docs/superpowers/specs/2026-05-01-wordpress-migration-design.md
@@ -204,12 +204,12 @@ import { fellows } from '../data/fellows.yaml'
 ## Migration Strategy
 
 ### Step 1: Content Extraction & Conversion
-- Export all WordPress posts/pages (content, metadata, featured images)
-- Convert HTML to markdown with YAML frontmatter
+- Scrape rendered HTML from the live WordPress site (XML export is not reliable — the page builder stores body content in a custom format that doesn't survive export)
+- Convert HTML to markdown with YAML frontmatter using a library (`turndown`, `node-html-markdown`) — **no LLM in the content path** (LLM-mediated tools paraphrase content silently)
 - Download and organize images into `src/assets/images/`
-- Extract structured data (fellows, speakers) into `.yaml` files
+- Extract structured data (fellows, speakers) into `.yaml` files by scraping profile pages
 
-**Effort:** Claude Code can automate much of this extraction and conversion
+**Effort:** Write a Node.js scraping script; Claude Code writes the script but never touches the content directly. See the `verbatim-content-extraction` skill.
 
 ### Step 2: Build Astro Skeleton
 - Create the directory structure above
@@ -244,18 +244,18 @@ import { fellows } from '../data/fellows.yaml'
 
 ## Phase 1 Success Criteria
 
-- [x] All WordPress content migrated to markdown/YAML
-- [x] All images migrated to `src/assets/`
-- [x] Homepage and all main pages render correctly
+- [ ] All WordPress content migrated to markdown/YAML
+- [ ] All images migrated to `src/assets/`
+- [x] Homepage and all main pages render correctly (sample content — real content pending migration)
 - [x] Component system working (fellows, speakers, etc. render from data)
 - [x] Navigation, header, footer functional
 - [x] Blog posts display with correct metadata
-- [x] Links and images working
-- [x] Staging site fully functional and tested
+- [ ] All links and images working with real content
+- [ ] Staging site fully functional and tested with real content
 - [x] SEO metadata (title, description, OG tags) present on all pages
-- [x] Accessibility baseline met (WCAG AA)
-- [x] Google Analytics integrated (meta tag)
-- [x] Team can navigate and understand the structure
+- [ ] Accessibility baseline met (WCAG AA)
+- [ ] Google Analytics integrated (real GA ID, not placeholder)
+- [ ] Team can navigate and understand the structure
 
 ---
 
@@ -332,7 +332,7 @@ Or with Claude Code:
 
 | Risk | Mitigation |
 |------|-----------|
-| Content extraction errors | Claude Code automates with human review; test thoroughly on staging |
+| Content extraction errors | Use direct HTTP scraping + a library (`turndown`) — never LLM-mediated tools, which silently paraphrase. Spot-check 5+ extracted files against live site before committing. |
 | Image paths breaking | Centralize image organization in `src/assets/`; use Astro's Image component for optimization |
 | Team members confused by git workflow | Phase 2 Decap CMS removes need for git; Phase 1 uses Claude Code to handle commits |
 | SEO metadata lost | Explicitly map WordPress metadata (title, description) to frontmatter; verify sitemap generation |


### PR DESCRIPTION
## Summary

- Updated Task 23 in the migration plan to replace the XML export approach with direct HTTP scraping (`fetch()` + `turndown`), based on what we learned from the failed PR #23
- Added a prominent warning that WebFetch (LLM-mediated) must never be used for verbatim content extraction — it silently paraphrases everything
- Added note that the WordPress page builder makes XML export unreliable; scraping rendered HTML is required
- Created a new `verbatim-content-extraction` skill documenting the correct pipeline for future agents

## Why

PR #23 was closed because content extracted via WebFetch was LLM-paraphrased rather than verbatim. This PR documents the correct approach so the next attempt (issue #24) doesn't repeat the same mistake.

The skill lives at `/home/node/.claude/skills/verbatim-content-extraction/SKILL.md` (outside the repo, in the shared skills directory) and is already registered and discoverable.

## Test plan

- [ ] Review Task 23 in the migration plan — confirm it describes the correct scraping pipeline
- [ ] Confirm the WebFetch warning is prominent and clear
- [ ] No code changes; docs-only PR

Closes #7