### PR TITLE
Note that GitHub issues are canonical, not the plan doc

### DIFF
--- a/docs/superpowers/plans/2026-05-01-wordpress-migration.md
+++ b/docs/superpowers/plans/2026-05-01-wordpress-migration.md
@@ -1,5 +1,7 @@
 # WordPress to Astro Migration — Implementation Plan (v2)
 
+> **Canonical work list lives in GitHub issues.** This document describes the strategy and phase structure, but the authoritative, up-to-date task list is the open issues in milestone "WordPress to Astro Migration" on github.com/jasoncrawford/rpi-homepage. The plan is evolving — new issues (e.g. A3 image consolidation, C2+ per-page-type components, D-page reproduction issues) are filed as we learn from each phase. If this document and the issue list disagree, **the issue list wins**.
+>
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 >
 > **READ THIS FIRST:** `verbatim-content-extraction` skill. Any LLM-mediated tool (WebFetch, asking Claude to "convert this HTML to markdown", etc.) silently paraphrases content. The migration must be **mechanical** — direct HTTP, library-based HTML→markdown, no LLM in the content path.


### PR DESCRIPTION
## Summary

Adds a header note to the migration plan clarifying that GitHub issues are the canonical task list. The plan describes strategy and phase structure but will lag as we learn (e.g. A3 image consolidation was just added without yet being in the plan body). If the two disagree, the issue list wins.

This is a small docs-only change to keep agents from treating the plan doc as the only source of truth.

## Test plan

- [ ] Read the new header note
