### PR TITLE
Milestone doc: make Status line non-editable by PRs

### DIFF
--- a/docs/2026-05-01-astro-migration-milestone.md
+++ b/docs/2026-05-01-astro-migration-milestone.md
@@ -139,7 +139,7 @@ No fixed deadline, but targeting completion in order of dependency (estimated ~2
 
 ---
 
-**Status:** Phase B in progress — B1 complete (merged PR #35), B2 (#30) next; Phase C in progress — C1 inventory in review (PR #37); C2–C12 to file after merge
+**Status:** See issue breakdown above (checkmarks = merged). Each PR updates only its own bullet; this line is not touched by implementing PRs.
 
 **Assigned to:** Brunel (implementation via 10 PR-sized issues)
 


### PR DESCRIPTION
The narrative **Status** line at the bottom of the milestone doc was a recurring merge-conflict hotspot — every implementing PR updated it, causing rebases on every parallel branch.

The fix: replace the narrative line with a pointer to the issue breakdown section (where PRs already update their own bullet with a ✓), and add a note that implementing PRs should leave the Status line alone.

No content is lost — the checkmarks in the issue breakdown already carry all the same information.
🤖 Generated with [Claude Code](https://claude.com/claude-code)