### PR TITLE
Update milestone doc: Phase A3 complete (merged PR #41)

### DIFF
--- a/docs/2026-05-01-astro-migration-milestone.md
+++ b/docs/2026-05-01-astro-migration-milestone.md
@@ -91,7 +91,7 @@ The original 10-issue plan was restructured after issues #1–#6 (foundation) me
 - #6 Data-Driven Components & Pages
 
 **v2 plan — capture-first, no LLM in content path:**
-- **Phase A — Mechanical Capture:** #27 ✓ crawl HTML (merged PR #33), #28 ✓ download images (merged PR #36), #39 consolidate canonical images (PR #41 in review)
+- **Phase A — Mechanical Capture:** #27 ✓ crawl HTML (merged PR #33), #28 ✓ download images (merged PR #36), #39 ✓ consolidate canonical images (merged PR #41)
 - **Phase B — Design System:** #29 ✓ extract tokens (merged PR #35), #30 (rebuild Base + CSS)
 - **Phase C — Page-Type Components:** #31 ✓ inventory (PR #37 in review) + C2–C12 to file after merge
 - **Phase D — Page-by-Page Reproduction:** filed after C1 inventory lands; one issue per page group; can run in parallel


### PR DESCRIPTION
Marks the #39 bullet as ✓ and updates it from "(PR #41 in review)" to "(merged PR #41)", following the convention established in PR #42.

No code changes.