### PR TITLE
Add visual diff harness for page/component verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .env.*
 !.env.example
 repl.log
+tmp/
 
 # Local Netlify folder
 .netlify

--- a/README.md
+++ b/README.md
@@ -7,11 +7,22 @@ Static site for [rootsofprogress.org](https://rootsofprogress.org), built with [
 **Requirements:** Node.js 20+
 
 ```bash
-npm install
+npm install      # also installs Chromium for visual-diff (via postinstall)
 npm run dev      # start dev server at http://localhost:4321
 npm run build    # build to dist/
 npm run preview  # preview the built site locally
 ```
+
+### Visual diff
+
+Before merging any PR that touches a page or component, take screenshots to compare local vs. live:
+
+```bash
+npm run visual-diff -- /          # homepage
+npm run visual-diff -- /about/    # any path
+```
+
+This saves PNGs to `tmp/visual-diff/`. See [docs/visual-diff.md](docs/visual-diff.md) for details.
 
 ## Project structure
 

--- a/docs/superpowers/plans/2026-05-01-wordpress-migration.md
+++ b/docs/superpowers/plans/2026-05-01-wordpress-migration.md
@@ -5,6 +5,8 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 >
 > **READ THIS FIRST:** `verbatim-content-extraction` skill. Any LLM-mediated tool (WebFetch, asking Claude to "convert this HTML to markdown", etc.) silently paraphrases content. The migration must be **mechanical** — direct HTTP, library-based HTML→markdown, no LLM in the content path.
+>
+> **REQUIRED ON PAGE/COMPONENT PRs:** `visual-page-verification` skill. Run `npm run visual-diff -- <path>`, read the PNGs with the Read tool, iterate until local matches live, and attach screenshots in the PR body. See `docs/visual-diff.md`.
 
 ---
 
@@ -101,7 +103,7 @@ One issue per page type. Each issue:
 - Builds a `*-demo.astro` route under `src/pages/_demo/` that renders sample data through the component, for visual review
 - Updates or replaces the existing PersonCard / HeroSection / EventCard placeholders rather than adding parallel ones
 
-Component fidelity is judged by visual diff against the original, not against the spec.
+Component fidelity is judged by visual diff against the original, not against the spec. Use `npm run visual-diff -- /demo/<component>` to screenshot the demo route and compare with `npm run visual-diff -- /<corresponding-live-path>`.
 
 ---
 
@@ -189,7 +191,7 @@ Phases A → B → C run sequentially. Within Phase D, page-group issues run in 
 1. **No LLM in the content path.** Not WebFetch, not "Claude, convert this HTML." LLM writes scripts; scripts process content.
 2. **No invented pages.** If a URL isn't in `capture/manifest.json`, it doesn't exist on the new site.
 3. **No invented copy.** All page body text traces back to a captured HTML file via a mechanical transform. If a string can't be traced, delete it.
-4. **Visual diff before merge.** Every page-shipping PR includes a side-by-side comparison in the PR description.
+4. **Visual diff before merge.** Every page-shipping PR includes a side-by-side comparison in the PR description. Use `npm run visual-diff -- <path>` to capture screenshots, read both PNGs with the Read tool, and paste them in the PR body. Invoke the `visual-page-verification` skill. Claiming "matches the original" without having read the screenshots is a red flag.
 5. **Capture is immutable.** `capture/` is read-only after Phase A. If the live site changes mid-migration, re-run capture as a separate PR with a fresh date stamp.
 6. **Scope: `rootsofprogress.org` only.** `blog.rootsofprogress.org` and `newsletter.rootsofprogress.org` are separate sites and are **not** part of this migration. Do not capture, convert, or reproduce content from those subdomains.
 

--- a/docs/visual-diff.md
+++ b/docs/visual-diff.md
@@ -1,0 +1,50 @@
+# Visual Diff
+
+`scripts/visual-diff.mjs` takes side-by-side screenshots of the local dev build vs. the live site, at desktop and mobile widths, so you can confirm a page looks right before merging.
+
+## How to run
+
+```bash
+npm run visual-diff -- /
+npm run visual-diff -- /about/
+npm run visual-diff -- /demo/homepage-demo
+```
+
+Output: four PNG files in `tmp/visual-diff/` (or two for `/demo/` paths — no live counterpart).
+
+File naming: `<slug>-{local,live}-{desktop,mobile}.png`
+
+## What it does
+
+1. Starts `astro dev` on port 4321 and waits for it to be ready.
+2. Opens Chromium (headless) via Playwright.
+3. Captures full-page screenshots at 1280×800 (desktop) and 375×800 (mobile).
+4. Tears down the dev server on exit, including on error.
+
+`/demo/...` paths are local-only — there's nothing to compare on the live site.
+
+## What to look for
+
+Open both PNGs and check:
+
+- **Layout**: columns, spacing, alignment match.
+- **Typography**: font, size, weight, line-height look the same.
+- **Images**: present, correctly sized, not broken.
+- **Colors / borders**: no unexpected differences.
+- **Mobile**: nav, stacking, tap targets make sense at 375 px.
+
+Small rendering deltas (anti-aliasing, font hinting) are fine. Layout shifts, missing elements, or wrong colors are not.
+
+## When they don't match
+
+1. Identify whether the difference is in your new code or a pre-existing divergence.
+2. If pre-existing, note it in the PR description so reviewers have context.
+3. If caused by your changes, iterate until local matches live (or the departure is intentional and approved).
+
+## Chromium install
+
+`npm install` automatically installs the Chromium browser via the `postinstall` script. If you skipped that or need to re-run it:
+
+```bash
+npx playwright install chromium
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
-        "@types/js-yaml": "^4.0.9"
+        "@types/js-yaml": "^4.0.9",
+        "playwright": "^1.59.1"
       },
       "engines": {
         "node": "^20.3.0 || >=22.0.0"
@@ -4331,6 +4332,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "node --test scripts/download-images.test.mjs scripts/consolidate-images.test.mjs"
+    "test": "node --test scripts/download-images.test.mjs scripts/consolidate-images.test.mjs",
+    "visual-diff": "node scripts/visual-diff.mjs",
+    "postinstall": "npx playwright install chromium"
   },
   "dependencies": {
     "astro": "^4.16.19",
@@ -18,6 +20,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.9"
+    "@types/js-yaml": "^4.0.9",
+    "playwright": "^1.59.1"
   }
 }

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Usage: node scripts/visual-diff.mjs <path>
+ * Examples:
+ *   node scripts/visual-diff.mjs /
+ *   node scripts/visual-diff.mjs /about/
+ *   node scripts/visual-diff.mjs /demo/homepage-demo
+ *
+ * Takes desktop (1280×800) and mobile (375×800) full-page screenshots of:
+ *   - Local:  http://localhost:4321<path>  (always)
+ *   - Live:   https://rootsofprogress.org<path>  (skipped for /demo/... paths)
+ *
+ * Saves PNGs to tmp/visual-diff/ and prints the paths.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { spawn } from 'child_process';
+import { chromium } from 'playwright';
+
+const LIVE_BASE = 'https://rootsofprogress.org';
+const LOCAL_PORT = 4321;
+const LOCAL_BASE = `http://localhost:${LOCAL_PORT}`;
+const OUT_DIR = 'tmp/visual-diff';
+const VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  mobile: { width: 375, height: 800 },
+};
+const DEV_READY_TIMEOUT_MS = 30_000;
+const DEV_POLL_MS = 500;
+
+function pathToSlug(urlPath) {
+  return urlPath.replace(/^\//, '').replace(/\/$/, '').replace(/\//g, '-') || 'home';
+}
+
+function isDemo(urlPath) {
+  return urlPath.startsWith('/demo/') || urlPath === '/demo';
+}
+
+async function waitForDevServer(url) {
+  const deadline = Date.now() + DEV_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(1000) });
+      if (res.ok || res.status < 500) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise(r => setTimeout(r, DEV_POLL_MS));
+  }
+  throw new Error(`Dev server at ${url} did not become ready within ${DEV_READY_TIMEOUT_MS}ms`);
+}
+
+async function screenshot(browser, url, slug, label, viewport) {
+  const ctx = await browser.newContext({ viewport });
+  const page = await ctx.newPage();
+  await page.goto(url, { waitUntil: 'networkidle' });
+  const outPath = path.join(OUT_DIR, `${slug}-${label}-${Object.keys(VIEWPORTS).find(k => VIEWPORTS[k] === viewport)}.png`);
+  await page.screenshot({ path: outPath, fullPage: true });
+  await ctx.close();
+  return outPath;
+}
+
+async function main() {
+  const urlPath = process.argv[2];
+  if (!urlPath || !urlPath.startsWith('/')) {
+    console.error('Usage: node scripts/visual-diff.mjs <path>  (e.g. / or /about/ or /demo/homepage-demo)');
+    process.exit(1);
+  }
+
+  await fs.mkdir(OUT_DIR, { recursive: true });
+
+  const slug = pathToSlug(urlPath);
+  const skipLive = isDemo(urlPath);
+
+  // Start astro dev server
+  const devServer = spawn('npx', ['astro', 'dev', '--port', String(LOCAL_PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+
+  let devServerExited = false;
+  devServer.on('exit', () => { devServerExited = true; });
+
+  const cleanup = () => {
+    if (!devServerExited) {
+      devServer.kill('SIGTERM');
+    }
+  };
+  process.on('exit', cleanup);
+  process.on('SIGINT', () => { cleanup(); process.exit(130); });
+  process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+
+  try {
+    console.log(`Starting astro dev on port ${LOCAL_PORT}…`);
+    await waitForDevServer(`${LOCAL_BASE}/`);
+    console.log('Dev server ready.\n');
+
+    const browser = await chromium.launch();
+    const saved = [];
+
+    try {
+      for (const [size, viewport] of Object.entries(VIEWPORTS)) {
+        const localUrl = `${LOCAL_BASE}${urlPath}`;
+        const localPath = await screenshot(browser, localUrl, slug, 'local', viewport);
+        console.log(`Saved: ${localPath}`);
+        saved.push(localPath);
+
+        if (!skipLive) {
+          const liveUrl = `${LIVE_BASE}${urlPath}`;
+          const livePath = await screenshot(browser, liveUrl, slug, 'live', viewport);
+          console.log(`Saved: ${livePath}`);
+          saved.push(livePath);
+        }
+      }
+    } finally {
+      await browser.close();
+    }
+
+    console.log(`\nDone. ${saved.length} screenshots in ${OUT_DIR}/`);
+    if (skipLive) {
+      console.log('(Live screenshots skipped: /demo/ path)');
+    }
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch(err => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `playwright` as a devDependency; `postinstall` installs Chromium automatically on `npm install`
- Adds `scripts/visual-diff.mjs`: boots `astro dev`, screenshots local + live at desktop (1280×800) and mobile (375×800), saves to `tmp/visual-diff/`, tears down cleanly
- Adds `npm run visual-diff -- <path>` script alias
- Adds `tmp/` to `.gitignore`
- Adds `docs/visual-diff.md` covering what it does, how to run it, what to look for, and what to do when screenshots don't match
- Adds `~/.claude/skills/visual-page-verification/SKILL.md` so agents are prompted to use this tool on any PR that ships a page or component

## Test plan

- [ ] `npm install` completes without error and Chromium is installed
- [ ] `npm run visual-diff -- /` produces 4 PNGs in `tmp/visual-diff/`
- [ ] Running it a second time works (clean dev server teardown on first run)
- [ ] `npm run visual-diff -- /demo/homepage-demo` produces 2 PNGs (local only, no live)
- [ ] `npm test` still passes (42 tests)
- [ ] Skill is discoverable via the Skill tool as `visual-page-verification`

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)