### PR TITLE
Allow Playwright CDN in devcontainer firewall

### DIFF
--- a/.devcontainer/firewall-extras.txt
+++ b/.devcontainer/firewall-extras.txt
@@ -1,3 +1,7 @@
 # Roots of Progress domain for content scraping
 rootsofprogress.org
 www.rootsofprogress.org
+
+# Playwright Chromium download (used by scripts/visual-diff.mjs via `playwright install chromium`)
+cdn.playwright.dev
+playwright.azureedge.net


### PR DESCRIPTION
## Summary

Adds `cdn.playwright.dev` and `playwright.azureedge.net` to the devcontainer firewall allowlist so `playwright install chromium` (run by the visual-diff harness from #58) can fetch the Chromium tarball.

## Why

Cassandra (working on PR #54) reported `npm run visual-diff` failing with `EHOSTUNREACH` to `cdn.playwright.dev`. Without the browser binary, agents can't run the visual diff and so can't satisfy the `visual-page-verification` skill requirement on every C/D PR. This is a hard block on the homepage and program-landing PRs (and on every page PR after).

## Test plan

- [ ] Once merged, restart any active devcontainer (or apply firewall update at runtime if the container supports that — same as the rootsofprogress.org allowance from PR #22)
- [ ] Re-run `npm install && npm run visual-diff -- /` from a devcontainer; confirm Chromium downloads and the script produces PNGs in `tmp/visual-diff/`

## Notes

Two hostnames included: `cdn.playwright.dev` is the primary as of recent Playwright versions; `playwright.azureedge.net` is the older fallback, included defensively in case the installed version pins to it.

Generated with [Claude Code](https://claude.com/claude-code)
