### PR TITLE
Force IPv4 in visual-diff to avoid container IPv6 hang

### DIFF
--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -20,7 +20,11 @@ import { chromium } from 'playwright';
 
 const LIVE_BASE = 'https://rootsofprogress.org';
 const LOCAL_PORT = 4321;
-const LOCAL_BASE = `http://localhost:${LOCAL_PORT}`;
+const LOCAL_HOST = '127.0.0.1';
+// Use 127.0.0.1 explicitly (not "localhost") so we never depend on whether
+// the OS resolves localhost to ::1 or 127.0.0.1. In Linux containers with
+// IPv6 firewalled, a "localhost" → ::1 lookup hangs silently.
+const LOCAL_BASE = `http://${LOCAL_HOST}:${LOCAL_PORT}`;
 const OUT_DIR = 'tmp/visual-diff';
 const VIEWPORTS = {
   desktop: { width: 1280, height: 800 },
@@ -73,8 +77,10 @@ async function main() {
   const slug = pathToSlug(urlPath);
   const skipLive = isDemo(urlPath);
 
-  // Start astro dev server
-  const devServer = spawn('npx', ['astro', 'dev', '--port', String(LOCAL_PORT)], {
+  // Start astro dev server. --host 127.0.0.1 forces IPv4 binding; without it
+  // Vite calls listen('localhost', ...) and Node may resolve to ::1, which
+  // means nothing is listening on 127.0.0.1 — see LOCAL_BASE comment above.
+  const devServer = spawn('npx', ['astro', 'dev', '--port', String(LOCAL_PORT), '--host', LOCAL_HOST], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
   });


### PR DESCRIPTION
## Summary

Forces IPv4 explicitly in `scripts/visual-diff.mjs` so the harness works in Linux devcontainers where the firewall blocks IPv6 outbound traffic. Without this, the script hangs for 30 seconds and times out with `Dev server at http://localhost:4321/ did not become ready`.

## What was happening

In a devcontainer where `ip6tables -P OUTPUT DROP` is in effect (the standard config from `devcontainer-claude`), two IPv6 quirks compound:

1. **Astro binds to IPv6 loopback only.** `astro dev` (via Vite) calls `listen('localhost', ...)`. Node's resolver hands back `::1` first, so Astro binds *only* to `[::1]:4321` — nothing listens on `127.0.0.1:4321`.
2. **The script's readiness fetch hits `localhost`**, which resolves the same way to `::1`. Outbound IPv6 packets are silently dropped by the container firewall, so the connection sits there until the per-attempt 1s `AbortSignal` fires. The retry loop never makes progress and gives up at 30s.

Diagnostic output from a real devcontainer:
```
$ ss -ltnp | grep 4321
LISTEN 0  511  [::1]:4321  [::]:*  users:(("node",pid=9013,fd=32))
$ curl --max-time 5 http://127.0.0.1:4321/
curl: (7) Failed to connect to 127.0.0.1 port 4321: Connection refused
$ curl --max-time 5 http://[::1]:4321/
curl: (28) Connection timed out after 5006 milliseconds
```

The script ran fine on macOS and on the original PR #58 verification (no IPv6 firewall), which masked the latent bug.

## Fix

- Spawn `astro dev` with `--host 127.0.0.1` so it binds to IPv4 loopback regardless of resolver behavior.
- Build `LOCAL_BASE` from `127.0.0.1` directly (not `localhost`) so the readiness check and Playwright go straight to the IPv4 socket with no DNS resolution.

Total diff: ~5 lines plus comments explaining the trap so future-us doesn't undo it.

## Test plan

- [x] Verified the bug exists in a Linux devcontainer (diagnostic output above)
- [x] Verified `astro dev --host 127.0.0.1` makes the dev server reachable on `127.0.0.1:4321` in the same container
- [x] `npm run visual-diff -- /` still works on macOS (no behavior change on platforms that already worked)
- [ ] Confirm `npm run visual-diff -- /` succeeds end-to-end in a Linux devcontainer after merge

## Notes

There may still be a related issue with the *live* URL (`https://rootsofprogress.org`) if it has AAAA records and Chromium prefers IPv6. Not addressed here — that hasn't actually been observed yet, and would be addressed differently (Chromium launch flag rather than script-level URL change). One step at a time.

Generated with [Claude Code](https://claude.com/claude-code)
