### PR TITLE
Make visual-diff harness fail-fast and exit cleanly

### DIFF
--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -14,8 +14,10 @@
  */
 
 import fs from 'fs/promises';
+import net from 'net';
 import path from 'path';
 import { spawn } from 'child_process';
+import { once } from 'events';
 import { chromium } from 'playwright';
 
 const LIVE_BASE = 'https://rootsofprogress.org';
@@ -39,6 +41,15 @@ function pathToSlug(urlPath) {
 
 function isDemo(urlPath) {
   return urlPath.startsWith('/demo/') || urlPath === '/demo';
+}
+
+async function isPortFree(port, host) {
+  return new Promise(resolve => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, host);
+  });
 }
 
 async function waitForDevServer(url) {
@@ -77,25 +88,37 @@ async function main() {
   const slug = pathToSlug(urlPath);
   const skipLive = isDemo(urlPath);
 
+  if (!(await isPortFree(LOCAL_PORT, LOCAL_HOST))) {
+    console.error(`Port ${LOCAL_PORT} on ${LOCAL_HOST} is already in use. Stop the process holding it (e.g. \`pkill -9 -f 'astro dev'\`) and retry.`);
+    process.exit(1);
+  }
+
   // Start astro dev server. --host 127.0.0.1 forces IPv4 binding; without it
   // Vite calls listen('localhost', ...) and Node may resolve to ::1, which
   // means nothing is listening on 127.0.0.1 — see LOCAL_BASE comment above.
+  // stderr is inherited so astro errors (port conflicts, config problems)
+  // surface immediately instead of being swallowed.
+  // detached:true puts npx and its astro grandchild into a new process
+  // group, so we can kill the whole tree with a negative PID below;
+  // without this, kill() reaches only npx and astro is reparented to init
+  // and keeps running, holding inherited file descriptors open.
   const devServer = spawn('npx', ['astro', 'dev', '--port', String(LOCAL_PORT), '--host', LOCAL_HOST], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    detached: false,
+    stdio: ['ignore', 'ignore', 'inherit'],
+    detached: true,
   });
 
   let devServerExited = false;
   devServer.on('exit', () => { devServerExited = true; });
 
-  const cleanup = () => {
-    if (!devServerExited) {
-      devServer.kill('SIGTERM');
-    }
+  // SIGKILL the whole process group. SIGTERM is ignored by Vite during HMR.
+  // Negative PID kills every process in devServer's group (npx + astro).
+  const killDevServer = () => {
+    if (devServerExited) return;
+    try { process.kill(-devServer.pid, 'SIGKILL'); } catch { /* already dead */ }
   };
-  process.on('exit', cleanup);
-  process.on('SIGINT', () => { cleanup(); process.exit(130); });
-  process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+  process.on('exit', killDevServer);
+  process.on('SIGINT', () => { killDevServer(); process.exit(130); });
+  process.on('SIGTERM', () => { killDevServer(); process.exit(143); });
 
   try {
     console.log(`Starting astro dev on port ${LOCAL_PORT}…`);
@@ -128,7 +151,8 @@ async function main() {
       console.log('(Live screenshots skipped: /demo/ path)');
     }
   } finally {
-    cleanup();
+    killDevServer();
+    if (!devServerExited) await once(devServer, 'exit');
   }
 }
 


### PR DESCRIPTION
## Summary

Three reliability fixes for `scripts/visual-diff.mjs`, all driven by a real debugging session in a Linux devcontainer that hit each one in turn.

## What changes

### 1. Pre-check that port 4321 is free

If a stray `astro dev` from an earlier run holds the port, the *new* astro silently fails to bind. The readiness probe then keeps hitting the *old* astro, you wait 30 seconds, and you get a misleading "did not become ready" timeout — even though something is actively listening on the port.

Now the script tries to bind 127.0.0.1:4321 itself before spawning astro, and bails immediately with the pkill command to fix it:

```
Port 4321 on 127.0.0.1 is already in use. Stop the process holding it
(e.g. `pkill -9 -f 'astro dev'`) and retry.
```

### 2. Inherit astro's stderr instead of swallowing it

Previously stdio was `['ignore', 'pipe', 'pipe']` and the pipes were never read. Astro could fail for any number of reasons (config error, missing dependency, port conflict) and the user would only ever see "Dev server did not become ready". Now stderr is inherited so real errors surface on the terminal in real time.

### 3. Spawn the dev server in a detached process group, kill it cleanly

This was the subtler one. `npx astro` runs astro as a *grandchild* of the script:

```
visual-diff.mjs
└── npx                 ← devServer.pid
      └── astro         ← actually serves :4321
```

The old `devServer.kill('SIGTERM')` (a) was ignored by Vite during HMR anyway, and (b) only reached `npx`, never `astro`. So astro got reparented to init and kept running, holding the inherited stderr FD open. That kept any downstream `tail` / `time` pipeline alive forever after the script printed "Done." — exactly the symptom that triggered this PR.

Fix: spawn with `detached: true` so the child becomes a process-group leader, then kill the whole group via a negative PID:

```js
process.kill(-devServer.pid, 'SIGKILL');
```

Also added `await once(devServer, 'exit')` in the finally block so the script doesn't return until the child has actually died — no half-second window of "parent exited, child still running."

## Test plan

- [x] Happy path on macOS: 4 PNGs produced in ~10s, exit 0, no astro lingering after exit.
- [x] Output piped through `tail` no longer hangs after "Done.".
- [x] Port-busy path: clean error message and exit 1 (manually verified by leaving an astro running in another terminal).
- [ ] Verify in a devcontainer that the visual-diff harness now runs end-to-end without the IPv6 hang fix from #62 + this cleanup.

## Notes

This is independent of the B2 work and helps any future page/component PR that uses the harness. It's a quality-of-life PR for the visual-diff harness itself.

Generated with [Claude Code](https://claude.com/claude-code)
