### PR TITLE
Docs: mark B2 complete, add CSS-debugging guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,30 @@ If there are differences, explain whether they're intentional.
 - Skipping because "it's a small change" — small CSS changes break layouts
 
 See `docs/visual-diff.md` for full details and Chromium install instructions.
+
+## Debugging CSS against the original
+
+`capture/css/global.css` is minified — rules run together. When a CSS value looks wrong, **verify which media query the original rule lives in** before writing your version. A rule inside `@media (max-width:767px)` that you apply at the base level will be wrong on desktop.
+
+Use Python to extract a rule with its surrounding context:
+
+```bash
+python3 << 'EOF'
+with open('capture/css/global.css') as f:
+    content = f.read()
+import re
+for keyword in ['header .logo{', 'footer .logo\\+']:
+    for m in re.finditer(keyword, content):
+        print(content[max(0, m.start()-80):m.start()+200])
+        print()
+EOF
+```
+
+If dynamic behavior (hover effects, scroll handling, height adjustments) differs from the static CSS, fetch the original theme JS:
+
+```bash
+# URL is in capture/html/index.html — look for theme/assets/js/app.js
+curl -s "https://rootsofprogress.org/wp-content/themes/theme/assets/js/app.js?ver=2.0.31" | head -200
+```
+
+The theme JS is the authoritative source for JS-driven behaviors (e.g. `li.last` height set dynamically on dropdown hover).

--- a/docs/2026-05-01-astro-migration-milestone.md
+++ b/docs/2026-05-01-astro-migration-milestone.md
@@ -92,7 +92,7 @@ The original 10-issue plan was restructured after issues #1–#6 (foundation) me
 
 **v2 plan — capture-first, no LLM in content path:**
 - **Phase A — Mechanical Capture:** #27 ✓ crawl HTML (merged PR #33), #28 ✓ download images (merged PR #36), #39 ✓ consolidate canonical images (merged PR #41)
-- **Phase B — Design System:** #29 ✓ extract tokens (merged PR #35), #30 (rebuild Base + CSS)
+- **Phase B — Design System:** #29 ✓ extract tokens (merged PR #35), #30 ✓ rebuild Base + CSS (merged PR #61)
 - **Phase C — Page-Type Components:** #31 ✓ inventory (PR #37 in review) + C2–C12 to file after merge
 - **Phase D — Page-by-Page Reproduction:** filed after C1 inventory lands; one issue per page group; can run in parallel
 - **Phase E — Verification:** filed after Phase D; visual diff, staging review, cutover prep


### PR DESCRIPTION
## Summary

- Mark issue #30 / PR #61 complete in milestone tracker
- Add a "Debugging CSS against the original" section to CLAUDE.md with:
  - Python snippet for extracting minified CSS rules with their media-query context (critical for catching rules that only apply inside a breakpoint)
  - How to fetch the original theme `app.js` for JS-driven behaviors

## Why

The B2 PR went through three rounds of review largely because of a pattern that's easy to get wrong: a CSS rule that lives inside a `@media (max-width:767px)` block in the original gets applied at the base level, behaving incorrectly on desktop. The Python extraction technique catches this immediately. Documenting it in the agent guide prevents the same mistake on future CSS-matching PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)