### PR TITLE
Add pixel-diff overlay to visual-diff harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,13 @@ npm run visual-diff -- /about/     # any path
 npm run visual-diff -- /demo/homepage-demo   # demo route (local only)
 ```
 
-Produces PNGs in `tmp/visual-diff/<slug>-{local,live}-{desktop,mobile}.png`. For `/demo/` paths, only local screenshots are taken.
+Produces PNGs in `tmp/visual-diff/<slug>-{local,live,diff}-{desktop,mobile}.png`. The `diff` PNG highlights every mismatched pixel in red. For `/demo/` paths, only local screenshots are taken (no live, no diff).
 
 ### Verify with Read tool
 
-Use the `Read` tool to view each PNG — Claude can see images. Check:
+Use the `Read` tool to view each PNG — Claude can see images.
+
+**Read the `diff` PNG first.** Red regions are exactly where local and live disagree. That tells you where to look. Then open `local` and `live` side-by-side to see *what* differs there. Check:
 
 - Layout: columns, spacing, and alignment match
 - Typography: font, size, weight, line-height match

--- a/docs/visual-diff.md
+++ b/docs/visual-diff.md
@@ -10,22 +10,25 @@ npm run visual-diff -- /about/
 npm run visual-diff -- /demo/homepage-demo
 ```
 
-Output: four PNG files in `tmp/visual-diff/` (or two for `/demo/` paths — no live counterpart).
+Output: six PNG files in `tmp/visual-diff/` (two for `/demo/` paths — no live counterpart, no diff).
 
-File naming: `<slug>-{local,live}-{desktop,mobile}.png`
+File naming: `<slug>-{local,live,diff}-{desktop,mobile}.png`
 
 ## What it does
 
 1. Starts `astro dev` on port 4321 and waits for it to be ready.
 2. Opens Chromium (headless) via Playwright.
 3. Captures full-page screenshots at 1280×800 (desktop) and 375×800 (mobile).
-4. Tears down the dev server on exit, including on error.
+4. For non-demo paths, generates a `diff` PNG per viewport that highlights every mismatched pixel in red on top of the local screenshot, and prints the percent of mismatched pixels.
+5. Tears down the dev server on exit, including on error.
 
-`/demo/...` paths are local-only — there's nothing to compare on the live site.
+`/demo/...` paths are local-only — there's nothing to compare on the live site, so no `live` or `diff` PNG is produced.
 
 ## What to look for
 
-Open both PNGs and check:
+**Start with the `diff` PNG.** Red regions are exactly where local and live disagree pixel-by-pixel. Use it to find what to focus on, then open the `local` and `live` PNGs side-by-side to see *what* the difference is.
+
+Check:
 
 - **Layout**: columns, spacing, alignment match.
 - **Typography**: font, size, weight, line-height look the same.
@@ -33,7 +36,7 @@ Open both PNGs and check:
 - **Colors / borders**: no unexpected differences.
 - **Mobile**: nav, stacking, tap targets make sense at 375 px.
 
-Small rendering deltas (anti-aliasing, font hinting) are fine. Layout shifts, missing elements, or wrong colors are not.
+Small rendering deltas (anti-aliasing, font hinting) are fine — pixelmatch tolerates them by default. Layout shifts, missing elements, or wrong colors light up clearly in the diff.
 
 ## When they don't match
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
-        "playwright": "^1.59.1"
+        "pixelmatch": "^7.2.0",
+        "playwright": "^1.59.1",
+        "pngjs": "^7.0.0"
       },
       "engines": {
         "node": "^20.3.0 || >=22.0.0"
@@ -4323,6 +4325,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -4380,6 +4395,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "playwright": "^1.59.1"
+    "pixelmatch": "^7.2.0",
+    "playwright": "^1.59.1",
+    "pngjs": "^7.0.0"
   }
 }

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -10,6 +10,9 @@
  *   - Local:  http://localhost:4321<path>  (always)
  *   - Live:   https://rootsofprogress.org<path>  (skipped for /demo/... paths)
  *
+ * For non-demo paths, also produces a pixel-diff overlay PNG per viewport
+ * (red highlights on the local screenshot wherever it disagrees with live).
+ *
  * Saves PNGs to tmp/visual-diff/ and prints the paths.
  */
 
@@ -17,6 +20,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import { spawn } from 'child_process';
 import { chromium } from 'playwright';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
 
 const LIVE_BASE = 'https://rootsofprogress.org';
 const LOCAL_PORT = 4321;
@@ -51,14 +56,50 @@ async function waitForDevServer(url) {
   throw new Error(`Dev server at ${url} did not become ready within ${DEV_READY_TIMEOUT_MS}ms`);
 }
 
-async function screenshot(browser, url, slug, label, viewport) {
+async function screenshot(browser, url, slug, label, viewport, size) {
   const ctx = await browser.newContext({ viewport });
   const page = await ctx.newPage();
   await page.goto(url, { waitUntil: 'networkidle' });
-  const outPath = path.join(OUT_DIR, `${slug}-${label}-${Object.keys(VIEWPORTS).find(k => VIEWPORTS[k] === viewport)}.png`);
+  const outPath = path.join(OUT_DIR, `${slug}-${label}-${size}.png`);
   await page.screenshot({ path: outPath, fullPage: true });
   await ctx.close();
   return outPath;
+}
+
+// Pad PNG to (width, height) on a white background so pixelmatch can compare
+// images of different heights (full-page screenshots routinely differ).
+// PNG.sync.read returns a plain object (not a PNG instance), so we copy the
+// raw RGBA buffer row-by-row instead of using PNG.bitblt.
+function padTo(png, width, height) {
+  if (png.width === width && png.height === height) return png;
+  const out = new PNG({ width, height });
+  out.data.fill(0xff);
+  const rowBytes = png.width * 4;
+  for (let y = 0; y < png.height; y++) {
+    png.data.copy(out.data, y * width * 4, y * rowBytes, (y + 1) * rowBytes);
+  }
+  return out;
+}
+
+async function diffPNGs(localPath, livePath, diffPath) {
+  const [localBuf, liveBuf] = await Promise.all([
+    fs.readFile(localPath),
+    fs.readFile(livePath),
+  ]);
+  const local = PNG.sync.read(localBuf);
+  const live = PNG.sync.read(liveBuf);
+  const width = Math.max(local.width, live.width);
+  const height = Math.max(local.height, live.height);
+  const a = padTo(local, width, height);
+  const b = padTo(live, width, height);
+  const diff = new PNG({ width, height });
+  const mismatched = pixelmatch(a.data, b.data, diff.data, width, height, {
+    threshold: 0.1,
+    alpha: 0.3,
+    diffColor: [255, 0, 0],
+  });
+  await fs.writeFile(diffPath, PNG.sync.write(diff));
+  return { mismatched, total: width * height };
 }
 
 async function main() {
@@ -102,15 +143,21 @@ async function main() {
     try {
       for (const [size, viewport] of Object.entries(VIEWPORTS)) {
         const localUrl = `${LOCAL_BASE}${urlPath}`;
-        const localPath = await screenshot(browser, localUrl, slug, 'local', viewport);
+        const localPath = await screenshot(browser, localUrl, slug, 'local', viewport, size);
         console.log(`Saved: ${localPath}`);
         saved.push(localPath);
 
         if (!skipLive) {
           const liveUrl = `${LIVE_BASE}${urlPath}`;
-          const livePath = await screenshot(browser, liveUrl, slug, 'live', viewport);
+          const livePath = await screenshot(browser, liveUrl, slug, 'live', viewport, size);
           console.log(`Saved: ${livePath}`);
           saved.push(livePath);
+
+          const diffPath = path.join(OUT_DIR, `${slug}-diff-${size}.png`);
+          const { mismatched, total } = await diffPNGs(localPath, livePath, diffPath);
+          const pct = ((mismatched / total) * 100).toFixed(2);
+          console.log(`Saved: ${diffPath}  (${pct}% mismatch)`);
+          saved.push(diffPath);
         }
       }
     } finally {


### PR DESCRIPTION
## Summary

Adds a pixel-diff overlay PNG per viewport to the visual-diff harness, so agents (and humans) can see at a glance *exactly* where local disagrees with live, instead of mentally subtracting two screenshots.

Motivation: agents have been converging slowly on visual matches even with the existing local/live screenshots. Looking at two PNGs and trying to spot the differences is hard, easy to skim, and easy to rationalize away. A red-pixel overlay is unambiguous.

## What changes

### 1. `scripts/visual-diff.mjs` produces a diff PNG per viewport

After the existing local + live pair is captured for a viewport, the script now generates a third PNG `tmp/visual-diff/<slug>-diff-<viewport>.png` using [`pixelmatch`](https://github.com/mapbox/pixelmatch). Mismatched pixels are highlighted in red on top of a faded local screenshot; matching regions are pale.

It also prints the percent of mismatched pixels per viewport, e.g.:

```
Saved: tmp/visual-diff/home-local-desktop.png
Saved: tmp/visual-diff/home-live-desktop.png
Saved: tmp/visual-diff/home-diff-desktop.png  (13.89% mismatch)
```

Skipped for `/demo/` paths (no live screenshot to compare against).

### 2. Padding to handle different heights

Full-page screenshots routinely differ in height between local and live. `pixelmatch` requires both inputs to be the same dimensions, so each PNG is padded with a white background up to the max(width, height) of the pair before diffing. Width matches the viewport width in practice, but `max()` is harmless if it ever doesn't.

### 3. Use `Buffer.copy` row-by-row, not `PNG.bitblt`

Tripped over this in testing: `PNG.sync.read()` returns a plain object with `.width`, `.height`, and `.data` (a Buffer), *not* a `PNG` instance — so the `bitblt` prototype method isn't there. Switched to a row-by-row `Buffer.copy` which is just as fast for our sizes and doesn't depend on the PNG instance API.

### 4. Docs and CLAUDE.md updates

Both `docs/visual-diff.md` and the visual-diff section of `CLAUDE.md` now explicitly direct agents to read the diff PNG **first** as the primary signal of where to focus, then open `local`/`live` to see *what* differs there.

## Test plan

- [x] `npm run visual-diff -- /` on macOS: 6 PNGs in ~8s, exit 0, no astro lingering.
- [x] Diff PNG visually highlights regions of mismatch (verified for the homepage — red bands clearly land on the divergent sections, e.g. the new C12 hero vs. the live header).
- [x] Percent-mismatch is printed per viewport.
- [x] Demo path still skips live (and therefore skips diff) — covered by the existing `if (!skipLive)` block; behavior unchanged for those paths.
- [ ] Confirm in a Linux devcontainer.

## Notes

- pixelmatch defaults: `threshold: 0.1`, `alpha: 0.3`, `diffColor: red`. These tolerate antialiasing and font hinting differences, so the diff stays focused on actual layout/content/color regressions.
- This stacks on the visual-diff cleanup work in PRs #62 and #63 — script still spawns/kills astro cleanly, still uses IPv4 explicitly.

Generated with [Claude Code](https://claude.com/claude-code)
