### PR TITLE
docs: visual-diff debugging + shared conventions for page types

### DIFF
--- a/docs/page-types.md
+++ b/docs/page-types.md
@@ -32,6 +32,21 @@ Migratable pages requiring Astro routes: **172**
 
 ---
 
+## Shared conventions (apply to every page type)
+
+- **CSS:** every rule in `public/styles.css` and component `<style is:global>` blocks must trace to a captured source rule in `capture/css/`. Don't invent rules — see the `no-invented-css` skill and the `CLAUDE.md` non-negotiable.
+- **Verbatim SVGs:** decorative SVGs (logos, icon patterns, the Fellowship logo divider, etc.) live as raw `*.svg.html` files under `src/components/svg/` and are imported with Vite's `?raw` loader, e.g.:
+  ```astro
+  ---
+  import logoMark from "../components/svg/fellowship-logo.svg.html?raw";
+  ---
+  <div class="sep" set:html={logoMark} />
+  ```
+  Never paste SVG path data into a string literal — the LLM silently truncates after a few hundred characters of `<path d="...">` data. See the `verbatim-content-extraction` skill.
+- **Visual diff** is required on every page/component PR — see `docs/visual-diff.md` (including the "measure, don't eyeball" technique for debugging high diffs).
+
+---
+
 ## Migratable Page Types
 
 ### 1. `homepage`

--- a/docs/visual-diff.md
+++ b/docs/visual-diff.md
@@ -43,6 +43,43 @@ Small rendering deltas (anti-aliasing, font hinting) are fine — pixelmatch tol
 2. If pre-existing, note it in the PR description so reviewers have context.
 3. If caused by your changes, iterate until local matches live (or the departure is intentional and approved).
 
+## Debugging high diffs — measure, don't eyeball
+
+When the diff PNG is busy with red and you can't tell what's wrong, **stop staring at the PNG and measure with Playwright**. Eyeballing typically takes hours and guesses wrong; measurement finds the offending property in seconds.
+
+The pattern: open both URLs in the same browser context, query the DOM, compare. Section heights first to find the offending section, then computed CSS on its children to find the offending property.
+
+```js
+// Inside a Playwright script. Run against http://127.0.0.1:4321/ and the live URL.
+const sections = await page.evaluate(() =>
+  [...document.querySelectorAll('main > section')].map(s => ({
+    cls: s.className,
+    h: Math.round(s.getBoundingClientRect().height),
+  }))
+);
+// Compare local[i].h vs live[i].h to find the section with the largest delta.
+
+// Then on the offending section, compare computed CSS on its children:
+const styles = await page.evaluate(() => {
+  const out = {};
+  for (const sel of ['.headline', '.title', '.bottoms', /* ... */]) {
+    const el = document.querySelector(sel);
+    if (!el) continue;
+    const cs = getComputedStyle(el);
+    out[sel] = { font: cs.fontFamily, color: cs.color, padding: cs.padding };
+  }
+  return out;
+});
+```
+
+Trace each property where local differs from live:
+
+- **In your CSS but not in captured?** → invented; delete it. (See the `no-invented-css` skill.)
+- **In captured but not in yours?** → missing; port it.
+- **In both at different specificity / media query?** → fix the cascade.
+
+Real result: this technique took the C12 homepage diff from 12% → 2.9% by surfacing six invented rules that no amount of eyeballing would have found.
+
 ## Chromium install
 
 `npm install` automatically installs the Chromium browser via the `postinstall` script. If you skipped that or need to re-run it:


### PR DESCRIPTION
## Summary

Two docs-only updates suggested at the end of the C12 (homepage) review, captured here so future page-type builds don't re-learn them:

- **`docs/visual-diff.md`** — adds a "Debugging high diffs — measure, don't eyeball" section. The diff PNG is good for finding the rough region of disagreement but bad for finding the property that actually differs. The Playwright pattern documented (query section heights, then `getComputedStyle` on children, both sides side-by-side) took the C12 homepage from a 12% diff down to 2.9% by surfacing six invented rules that wouldn't have been visible from staring at red pixels.
- **`docs/page-types.md`** — adds a "Shared conventions" section above the per-page-type listing covering rules that apply to every C-issue going forward: no invented CSS (with reference to the `no-invented-css` skill), verbatim SVGs via `?raw` imports from `src/components/svg/` (with reference to `verbatim-content-extraction`), visual-diff required. Pulls together rules previously scattered across `CLAUDE.md` and skills so each page-type build doesn't rediscover them from scratch.

## Test plan

- [x] `npm run build` succeeds (docs-only, no behaviour changes)
- [ ] Reviewer scans the two diff hunks for prose accuracy