### PR TITLE
fix(visual-diff): scroll page before screenshot to trigger lazy images

### DIFF
--- a/docs/visual-diff.md
+++ b/docs/visual-diff.md
@@ -17,7 +17,7 @@ File naming: `<slug>-{local,live,diff}-{desktop,mobile}.png`
 
 1. Starts `astro dev` on port 4321 and waits for it to be ready.
 2. Opens Chromium (headless) via Playwright.
-3. Captures full-page screenshots at 1280×800 (desktop) and 375×800 (mobile).
+3. For each viewport, loads the page, scrolls top-to-bottom in half-viewport steps so each `loading="lazy"` image enters the intersection observer's viewport and starts its network request, scrolls back to top (so any scroll-state header class resets), waits for network idle, then captures a full-page screenshot at 1280×800 (desktop) and 375×800 (mobile).
 4. For non-demo paths, generates a `diff` PNG per viewport that highlights every mismatched pixel in red on top of the local screenshot, and prints the percent of mismatched pixels.
 5. Tears down the dev server on exit, including on error.
 

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -56,10 +56,34 @@ async function waitForDevServer(url) {
   throw new Error(`Dev server at ${url} did not become ready within ${DEV_READY_TIMEOUT_MS}ms`);
 }
 
+// Scroll from top to bottom in half-viewport steps so each lazy-loaded image
+// (loading="lazy") enters the intersection observer's viewport and starts its
+// network request. Then scroll back to top so any scroll-state classes on the
+// header (e.g. header.scroll) reset before the screenshot.
+async function triggerLazyImages(page) {
+  await page.evaluate(async () => {
+    await new Promise(resolve => {
+      let y = 0;
+      const step = window.innerHeight / 2;
+      const interval = setInterval(() => {
+        window.scrollTo(0, y);
+        y += step;
+        if (y >= document.body.scrollHeight) {
+          clearInterval(interval);
+          window.scrollTo(0, 0);
+          resolve();
+        }
+      }, 100);
+    });
+  });
+  await page.waitForLoadState('networkidle');
+}
+
 async function screenshot(browser, url, slug, label, viewport, size) {
   const ctx = await browser.newContext({ viewport });
   const page = await ctx.newPage();
   await page.goto(url, { waitUntil: 'networkidle' });
+  await triggerLazyImages(page);
   const outPath = path.join(OUT_DIR, `${slug}-${label}-${size}.png`);
   await page.screenshot({ path: outPath, fullPage: true });
   await ctx.close();


### PR DESCRIPTION
## Summary

- `scripts/visual-diff.mjs` previously called `page.screenshot({ fullPage: true })` immediately after `goto`, so images with `loading="lazy"` below the initial viewport never entered the intersection observer and never started loading. They were absent from both local and live captures, masking real layout differences.
- New `triggerLazyImages(page)` helper scrolls top-to-bottom in half-viewport steps, returns to top (so any `header.scroll`-style class resets), then awaits `networkidle` before the screenshot fires.
- Updated `docs/visual-diff.md` step 3 to describe the auto-scroll.

## Visual diff — `/` desktop & mobile

Re-ran `npm run visual-diff -- /` against this branch. Read the resulting PNGs:

- **Press cards now load.** Reason / Vox / BBC Future thumbnails appear in both local and live screenshots, on desktop and mobile. Before this fix they were blank in both captures.
- Diff: 2.41% desktop, 6.21% mobile — consistent with pre-existing typographic / layout differences already known in the homepage migration. No new red regions introduced by the change itself.
- Layout, headers, footers all align as before.

## Test plan

- [x] `npm test` — 42/42 pass
- [x] `npm run visual-diff -- /` — completes; press card images visible in both local and live PNGs
- [ ] User UAT: re-run on another lazy-image page (e.g. `/about/`) and confirm captures look like the live site

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)