### PR TITLE
Restore visual-diff cleanup behavior + warn against pkill node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ Produces PNGs in `tmp/visual-diff/<slug>-{local,live,diff}-{desktop,mobile}.png`
 
 Build at the real URL and diff against live. Don't introduce `/demo/...` routes for visual review — they exist for sample-data sandboxing we no longer need (the captured site has the real content), and they make it easy to skip the live comparison entirely.
 
+### If port 4321 is busy
+
+The script pre-checks port 4321 and bails immediately with a message that includes the right command. Do exactly what it says: `pkill -9 -f 'astro dev'`.
+
+**Never run `pkill -f node` (or `-9 node`, or any unscoped node kill).** Claude Code itself is a node process — those commands kill the agent's own shell, ending the session mid-task. This has happened twice already. Always scope kills to `'astro dev'` or use `ss -tlnp | grep 4321` to find the exact PID and kill that one.
+
 ### Verify with Read tool
 
 Use the `Read` tool to view each PNG — Claude can see images.

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -16,8 +16,10 @@
  */
 
 import fs from 'fs/promises';
+import net from 'net';
 import path from 'path';
 import { spawn } from 'child_process';
+import { once } from 'events';
 import { chromium } from 'playwright';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
@@ -35,6 +37,15 @@ const DEV_POLL_MS = 500;
 
 function pathToSlug(urlPath) {
   return urlPath.replace(/^\//, '').replace(/\/$/, '').replace(/\//g, '-') || 'home';
+}
+
+async function isPortFree(port, host) {
+  return new Promise(resolve => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, host);
+  });
 }
 
 async function waitForDevServer(url) {
@@ -132,23 +143,39 @@ async function main() {
 
   const slug = pathToSlug(urlPath);
 
-  // Start astro dev server
+  if (!(await isPortFree(LOCAL_PORT, '127.0.0.1'))) {
+    console.error(`Port ${LOCAL_PORT} on 127.0.0.1 is already in use. Stop the process holding it (e.g. \`pkill -9 -f 'astro dev'\` — do NOT pkill node, that kills your shell/agent) and retry.`);
+    process.exit(1);
+  }
+
+  // Start astro dev server.
+  // - --host 127.0.0.1 forces IPv4 binding; without it Vite calls
+  //   listen('localhost', ...) and Node may resolve to ::1, leaving nothing
+  //   listening on 127.0.0.1.
+  // - stderr is inherited so astro errors (port conflicts, config problems)
+  //   surface immediately instead of being swallowed.
+  // - detached:true puts npx and its astro grandchild into a new process
+  //   group, so we can kill the whole tree with a negative PID below.
+  //   Without this, kill() reaches only npx and astro is reparented to init
+  //   and keeps running, holding inherited file descriptors open and the
+  //   port pinned for the next run.
   const devServer = spawn('npx', ['astro', 'dev', '--port', String(LOCAL_PORT), '--host', '127.0.0.1'], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    detached: false,
+    stdio: ['ignore', 'ignore', 'inherit'],
+    detached: true,
   });
 
   let devServerExited = false;
   devServer.on('exit', () => { devServerExited = true; });
 
-  const cleanup = () => {
-    if (!devServerExited) {
-      devServer.kill('SIGTERM');
-    }
+  // SIGKILL the whole process group. SIGTERM is ignored by Vite during HMR.
+  // Negative PID kills every process in devServer's group (npx + astro).
+  const killDevServer = () => {
+    if (devServerExited) return;
+    try { process.kill(-devServer.pid, 'SIGKILL'); } catch { /* already dead */ }
   };
-  process.on('exit', cleanup);
-  process.on('SIGINT', () => { cleanup(); process.exit(130); });
-  process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+  process.on('exit', killDevServer);
+  process.on('SIGINT', () => { killDevServer(); process.exit(130); });
+  process.on('SIGTERM', () => { killDevServer(); process.exit(143); });
 
   try {
     console.log(`Starting astro dev on port ${LOCAL_PORT}…`);
@@ -182,7 +209,8 @@ async function main() {
 
     console.log(`\nDone. ${saved.length} screenshots in ${OUT_DIR}/`);
   } finally {
-    cleanup();
+    killDevServer();
+    if (!devServerExited) await once(devServer, 'exit');
   }
 }
 


### PR DESCRIPTION
## Summary

Restores the visual-diff cleanup behavior added in #63 (which got silently reverted by #61) and adds a CLAUDE.md note warning agents off `pkill -f node`. Two real incidents motivated this — twice now an agent has hit a stale astro on port 4321, escalated through pkill commands, and ended up running `pkill -9 -f node`, which kills the agent's own shell because Claude Code itself runs as a node process.

## How the cleanup got reverted

PR #61 (B2: Base layout) was opened before #62/#63 existed. The agent on B2 hit the same IPv6 hang independently and committed its own fix as `f4b669b "Fix visual-diff script for IPv6-disabled container environments"` — same title as #62, but a *different* implementation that lacked the cleanup work added in #63 (port pre-check, detached process group, inherited stderr, post-kill exit-wait).

When B2 merged, the older script ended up on main. PRs #65 (pixel-diff overlay), #67 (docs), #68 (lazy images), and #70 (drop /demo) all built on the regressed file without anyone noticing — the revert was a 50-line patch invisible inside a 1500-line CSS rewrite.

## What this restores

In `scripts/visual-diff.mjs`:

- **`isPortFree()` pre-check**, with an error message that includes both the right command (`pkill -9 -f 'astro dev'`) *and* an explicit "do NOT pkill node" warning embedded in the message itself.
- **`detached: true`** on the `npx astro` spawn. `npx` runs astro as a grandchild; without a process group, `kill('SIGTERM')` only reaches `npx` and astro gets reparented to init, leaking and holding the port pinned for the next run.
- **`process.kill(-pid, 'SIGKILL')`** on cleanup — Vite ignores SIGTERM during HMR, so SIGKILL is required, and the negative PID kills the whole process group.
- **Inherited stderr** so astro's startup errors surface in real time instead of being swallowed by an unread pipe.
- **`await once(devServer, 'exit')` in `finally`** so the script doesn't return until astro is actually dead — closes the half-second window where the parent has exited but the child hasn't.

## CLAUDE.md addition

A new "If port 4321 is busy" subsection under the visual-diff section. Two messages: do exactly what the script's bail message says (`pkill -9 -f 'astro dev'`); and **never** run `pkill -f node` because that kills the agent itself. The script's error message is the first line of defense; the CLAUDE.md note is the second.

## Test plan

- [x] Happy path: `npm run visual-diff -- /` produces 6 PNGs in ~20s, exit 0, no astro lingering. (Verified locally on macOS.)
- [x] Port-busy path: with a stray astro held on 4321, the script bails immediately with the new message and exit 1 (instead of timing out after 90s). (Verified by spawning a leftover astro and re-running.)
- [ ] Verify in a Linux devcontainer (where the original incidents happened).

## Note on prevention

This regression slipped through because:
1. The duplicate-titled commit on a long-running branch wasn't visible in either PR's diff in isolation.
2. `scripts/visual-diff.mjs` isn't covered by tests.
3. Reviewing a 1500-line CSS PR by eyeball doesn't catch a 50-line script revert.

Worth considering for the future: rebasing long-lived branches on latest `main` before merge, or at least always eyeballing the diffs of any non-feature files (scripts, configs, package.json) the PR touches. Not changing process here — flagging for awareness.

Generated with [Claude Code](https://claude.com/claude-code)
